### PR TITLE
softirq: Soften budget/backlog tuning suggestion

### DIFF
--- a/xsos
+++ b/xsos
@@ -2532,7 +2532,7 @@ SOFTIRQ() {
   gawk '{if (strtonum("0x" $2) > 0) exit 177}' "$softirq_input_file"
   
   if [[ $? -eq 177 ]]; then
-    echo -e "${XSOS_INDENT_H1}${c[Warn1]}Backlog max has been reached, needs to be increased!${c[0]}$backlog"
+    echo -e "${XSOS_INDENT_H1}${c[Warn1]}Backlog max has been reached, consider reviewing backlog tunable.${c[0]}$backlog"
   else
     echo -e "${XSOS_INDENT_H1}Backlog max is sufficient${c[0]}$backlog"
   fi
@@ -2540,7 +2540,7 @@ SOFTIRQ() {
   
   gawk '{if (strtonum("0x" $3) > 0) exit 177}' "$softirq_input_file"
   if [[ $? -eq 177 ]]; then
-    echo -e "${XSOS_INDENT_H1}${c[Warn1]}Budget is not sufficient, needs to be increased!${c[0]}$budget"
+    echo -e "${XSOS_INDENT_H1}${c[Warn1]}Budget is not sufficient, consider reviewing budget tunable.${c[0]}$budget"
   else
     echo -e "${XSOS_INDENT_H1}Budget is sufficient${c[0]}$budget"
   fi


### PR DESCRIPTION
People often see the "increase this" message and go off on tangents
making these values far too large when there are other things to be
considered. In a way I wish we'd never put these in xsos, but they are a
handy prompt to look into other areas of softirq performance some more.

Soften the warning to "consider reviewing" this tunable, rather than
alert the user that the tunables are too small, which they probably
aren't. I've also modified the linked knowledgebase solution to advise
considering a more holistic performance tuning view.

Signed-off-by: Jamie Bainbridge jamie.bainbridge@gmail.com
