### PR TITLE
show proc cmd with -p --threads option

### DIFF
--- a/xsos
+++ b/xsos
@@ -2952,9 +2952,13 @@ PSCHECK() {
       gawk '
         {
           if ($2=="-") {
-            $2 = pid; $11 = "[thread_of_pid_"pid"]"
+            $2 = pid; $11 = cmd
           }
-          else pid = $2
+          else {
+            pid = $2
+            cmd = $11
+            for(i=12;i<=NF;i++) cmd = cmd FS $i
+          }
           print
         }
       ' <<<"$ps_input_thrds_raw"


### PR DESCRIPTION
When initially implemented, the --threads option showed
[thread_of_pid_PID] in the COMMAND column instead of the command. This
is because the original data from "ps auxwwwm" only has a dash "-" in
the COMMAND column for threads. However, the [thread_of_pid_PID] isn't
very useful output because we are already showhing the PID in the
second column.

This commit finishes the job. We now show the proper COMMAND for each
thread.