### PR TITLE
Add "lost" to packet loss grep

### DIFF
--- a/xsos
+++ b/xsos
@@ -183,7 +183,7 @@ fi
 
 # XSOS_ETHTOOL_ERR_REGEX (str: regular expression)
 #   Configures what ETHTOOL() uses to generate the data under the "Interface Errors" heading
-    : ${XSOS_ETHTOOL_ERR_REGEX:="Missing ethtool_-S file|(drop|disc|err|fifo|buf|fail|miss|OOB|fcs|full|frags|hdr|tso|pause).*: [^0]"}
+    : ${XSOS_ETHTOOL_ERR_REGEX:="Missing ethtool_-S file|(drop|disc|err|fifo|buf|fail|miss|OOB|fcs|full|frags|hdr|tso|pause|lost).*: [^0]"}
 
 # XSOS_LSPCI_NET_REGEX (str: regular expression)
 #   Configures what LSPCI() uses to search for peripherals under the "Net" heading


### PR DESCRIPTION
8139too logs its ring buffer loss as "rx_lost_in_ring"

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>