### PR TITLE
sysctl: Add vm.min_free_kbytes and vm.vfs_cache_pressure

### DIFF
--- a/xsos
+++ b/xsos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# xsos v0.7.17 last mod 2018/10/15
+# xsos v0.7.18 last mod 2018/10/18
 # Latest version at <http://github.com/ryran/xsos>
 # RPM packages available at <http://people.redhat.com/rsawhill/rpms>
 # Copyright 2012-2018 Ryan Sawhill Aroha <rsaw@redhat.com>
@@ -2926,6 +2926,8 @@ SYSCTL() {
   __Pa vm.oom_kill_allocating_task "[bool] "  '{if ($1==0) printf "\"0\"%s  (scan tasklist)", H0; else printf "\"1\"%s  (kill OOM-triggering task)", H0}'
   __Pa vm.panic_on_oom "[0-2] "  '{if ($1==0) printf "\"0\"%s  (no panic)", H0; else if ($1==1) printf "\"1\"%s  (no panic if OOM-triggering task limited by mbind/cpuset)", H0; else if ($1==2) printf "\"2\"%s  (always panic)", H0}'
   __P vm.swappiness "[0-100] "
+  __P vm.min_free_kbytes ""
+  __P vm.vfs_cache_pressure "[0-100] "
   echo -en $XSOS_HEADING_SEPARATOR
 }
 


### PR DESCRIPTION
    vm.min_free_kbytes is popularily used for vm tunings.

    vm.vfs_cache_pressure is also pupularily used for caching of
    directory and inode objects.

Signed-off-by: Jay Shin <jaeshin@redhat.com>