### PR TITLE
interrupts: fix a regex

### DIFF
--- a/xsos
+++ b/xsos
@@ -1560,7 +1560,7 @@ INTERRUPT() {
     NR > 1 {
       printf "%'$indent's ", $1
       for (i=2; i <= NF; i++) {
-        if ($i ~ "[a-zA-Z]")
+        if ($i ~ "[^0-9]")
           printf " %s", $i
         else if($i > 0)
           printf "▊"


### PR DESCRIPTION
I found a bug in the part of interrupts.

In case there is a line like below in /proc/interrupts,
 29:          0          0          0          0          0          0          0          0  IR-PCI-MSI-edge      0000:00:11.5

I expected the output will be as below.
 29: ........ IR-PCI-MSI-edge 0000:00:11.5

But, actual output is as below.
 29: ........ IR-PCI-MSI-edge▊

I checked the source code, and I found the regex is wrong.
According to the source code, it outputs the field as it is only in case the field contains alphabet.
But actually '.' or ':' can be located there, too.
So, I think the regex would be better to change [a-zA-Z] to [^0-9] like this PR.

Thank you.