### PR TITLE
Make _parse_periphs() gawk case insensitive

### DIFF
--- a/xsos
+++ b/xsos
@@ -187,7 +187,7 @@ fi
 
 # XSOS_LSPCI_NET_REGEX (str: regular expression)
 #   Configures what LSPCI() uses to search for peripherals under the "Net" heading
-    : ${XSOS_LSPCI_NET_REGEX:="(Ethernet controller|Network controller|InfiniBand)( \[[0-9]{4}\])?:"}
+    : ${XSOS_LSPCI_NET_REGEX:="(Ethernet controller|Network controller|InfiniBand)( \[[0-9]{4}\])?"}
 
 # XSOS_LSPCI_STORAGE_REGEX (str: regular expression)
 #   Configures what LSPCI() uses to search for peripherals under the "Storage" heading
@@ -2024,7 +2024,7 @@ LSPCI() {
   
   _parse_periphs() {
     local regex=${1}
-    gawk -vH_IMP="${c[Imp]}" -vH2="${c[H2]}" -vH0="${c[0]}" "
+    gawk -v IGNORECASE=1 -vH_IMP="${c[Imp]}" -vH2="${c[H2]}" -vH0="${c[0]}" "
       /${regex}/"'{
         # Save
         split($1, slot, ":")


### PR DESCRIPTION
Some devices have an unexpected PCI class so the original XSOS_LSPCI_*_REGEX
will miss them.

We relax the pattern matching by making it case insensitive and removing the
colon.

Fixes: #10

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>