### PR TITLE
meminfo: Accurately describe THP usage

### DIFF
--- a/xsos
+++ b/xsos
@@ -1838,7 +1838,7 @@ MEMINFO() {
       
       printf    "  %sTHP:%s\n", H2, H0
       if (Anonhugepages == 0)
-        printf  "    THP Disabled\n"
+        printf  "    THP not currently in use\n"
       else {
         printf  "    %s kB allocated to THP %s\n", Anonhugepages, H0
       }


### PR DESCRIPTION
THP can still be enabled without the system having allocated any
anonymous huge pages. Change text to reflect THP "usage" rather than
being turned off.

It would be nice to have proper display of enabled/disabled/madvise in
future, as described in: https://github.com/ryran/xsos/issues/254

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>
Reported-by: karlabbott on GitHub