### PR TITLE
TEAMING: fix running against local system

### DIFF
--- a/xsos
+++ b/xsos
@@ -4001,7 +4001,7 @@ trap "rm -rf $TMPDIR 2>/dev/null" EXIT
     [[ -n $softirq ]] && SOFTIRQ /
     [[ -n $netdev ]]  && NETDEV /
     [[ -n $bonding ]] && BONDING /
-    [[ -n $teaming ]] && TEAMING /
+    [[ -n $teaming ]] && TEAMING
     [[ -n $ip ]]      && IPADDR
     [[ -n $all ]]     && XSOS_IP_VERSION=6 IPADDR
     [[ -n $sysctl ]]  && SYSCTL / 2>/dev/null


### PR DESCRIPTION
Currently, `TEAMING` doesn't work against the local system because it's called with `/` as an argument, but then the argument is checked with `[[ -z $1 ]]`.

This PR fixes the call to the `TEAMING` module by omitting the argument when running against a live system.