### PR TITLE
Allow -p/--ps option in the live local mode as well

### DIFF
--- a/xsos
+++ b/xsos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# xsos v0.7.31 last mod 2024-03-06
+# xsos v0.7.32 last mod 2024-05-28
 # Latest version at <http://github.com/ryran/xsos>
 # RPM packages available at <http://people.redhat.com/rsawhill/rpms>
 # Copyright 2012-2018 Ryan Sawhill Aroha <rsaw@redhat.com>
@@ -4012,6 +4012,7 @@ trap "rm -rf $TMPDIR 2>/dev/null" EXIT
     [[ -n $ip ]]      && IPADDR
     [[ -n $all ]]     && XSOS_IP_VERSION=6 IPADDR
     [[ -n $sysctl ]]  && SYSCTL / 2>/dev/null
+    [[ -n $ps ]]      && PSCHECK
     [[ -n $ss ]]      && SSCHECK
     [[ -n $firewall ]]&& FIREWALL
     [[ -n $ifcfg ]]   && IFCFG


### PR DESCRIPTION
Looks like an oversight when the -p/--ps option was added originally, but without this there's no output from "xsos -p" (live).