### PR TITLE
[xsos] If sosroot is a file, try to unarchive it first

### DIFF
--- a/xsos
+++ b/xsos
@@ -3968,6 +3968,8 @@ trap "rm -rf $TMPDIR 2>/dev/null" EXIT
       # sosroot is a standard file, try to look for an archive supported by tar
       newroot="$(mktemp -qd)" \
       && tar xf "${sosroot}" -C "${newroot}" \
+      && { find "${newroot}" -type d -print0 | xargs -r0 chmod 0700; } \
+      && { find "${newroot}" -type f -print0 | xargs -r0 chmod 0600; } \
       && sosroot="$(find "$newroot" -mindepth 1 -maxdepth 1 -type d)" \
       || exit 1
     fi

--- a/xsos
+++ b/xsos
@@ -3964,6 +3964,13 @@ trap "rm -rf $TMPDIR 2>/dev/null" EXIT
 
   # If SOSREPORT-ROOT provided, use that
   elif [[ -n $sosroot ]]; then
+    if [[ -f $sosroot ]]; then
+      # sosroot is a standard file, try to look for an archive supported by tar
+      newroot="$(mktemp -qd)" \
+      && tar xf "${sosroot}" -C "${newroot}" \
+      && sosroot="$(find "$newroot" -mindepth 1 -maxdepth 1 -type d)" \
+      || exit 1
+    fi
     SOS_CHECKFILE bios    {,sos_commands/{kernel.,hardware/}}dmidecode \
                                                                && DMIDECODE "$sosroot"
     SOS_CHECKFILE os      "proc/"                              && OSINFO    "$sosroot"


### PR DESCRIPTION
With help of tar, try to unarchive a sosreport file provided in command line instead of directory as expected in original version