### PR TITLE
Fix gawk crash in ps output

### DIFF
--- a/xsos
+++ b/xsos
@@ -3290,7 +3290,7 @@ PSCHECK() {
       {
         # Print fields up through %MEM
         for (i=1; i<fieldvsz; i++)
-          printf $i"❚"
+          printf "%s❚",$i
         
         # Print fields VSZ & RSS
         for (i=fieldvsz; i<fieldtty; i++) {


### PR DESCRIPTION
Fix gawk crash when using `printf` to print column names that contain a `%` from the ps output

This seems to come from this change in gawk 5.3.1

        8. The implementation of printf/sprintf has been thoroughly reworked
           in order to make the code more maintainable and to fix a goodly
           number of corner cases.

Looks like printf was interpreting "%CPU" or "%MEM" as a format spec and expecting an argument to be provided, otherwise it crashes with the following error:
        gawk: cmd. line:32: (FILENAME=- FNR=1) fatal: not enough arguments to satisfy format string

Fixes #285