### PR TITLE
docs/ci: refresh README help; add lint; fix ShellCheck; guard /etc/inittab fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Bash syntax check
+        run: |
+          bash -n xsos
+          bash -n xsos-bash-completion.bash
+
+      - name: ShellCheck (errors only)
+        run: |
+          shellcheck -S error -x xsos xsos-bash-completion.bash

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -12,6 +12,20 @@ Try to keep roughly within the established bash/awk style.
 
 ## Testing
 
+### Lint / static checks
+
+The CI runs the following checks locally; please run them before opening a PR:
+
+```bash
+bash -n xsos
+bash -n xsos-bash-completion.bash
+
+# ShellCheck is optional locally but strongly recommended.
+# CI runs ShellCheck in "errors only" mode to catch real breakage while avoiding
+# a huge amount of warning-only churn.
+shellcheck -S error -x xsos xsos-bash-completion.bash
+```
+
 ### Targets - what xsos is run against
 
 Where possible, test against sosreports from the in-support versions of RHEL and Ubuntu LTS.

--- a/README.md
+++ b/README.md
@@ -115,44 +115,48 @@ OS
 ```
 
 
-**While xsos is always being improved, here's the minimal help page from v0.5.6:**
+**While xsos is always being improved, here's the current minimal help page (run `xsos -h`):**
 
 ```
-Usage: xsos [DISPLAY OPTIONS] [-6abokcmdtlerngisp] [SOSREPORT ROOT]
-  or:  xsos [DISPLAY OPTIONS] {--B|--C|--M|--D|--T|--L|--R|--N|--G|--I|--P FILE}...
+Usage: xsos [DISPLAY OPTIONS] [-6abokcfmdtlerngispSFIN] [SOSREPORT ROOT]
+  or:  xsos [DISPLAY OPTIONS] {--B|--C|--F|--M|--D|--T|--L|--R|--N|--G|--I|--P FILE}...
   or:  xsos [-?|-h|--help]
-  or:  xsos [-U|--update]
 
 Display system info from localhost or extracted sosreport
 
 Content options:
- -a, --all      show everything
- -b, --bios     show info from dmidecode
- -o, --os       show hostname, distro, SELinux, kernel info, uptime, etc
- -k, --kdump    inspect kdump configuration
- -c, --cpu      show info from /proc/cpuinfo
- -m, --mem      show info from /proc/meminfo
- -d, --disks    show info from /proc/partitions + dm-multipath synopsis
- -t, --mpath    show info from dm-multipath
- -l, --lspci    show info from lspci
- -e, --ethtool  show info from ethtool
- -r, --softirq  show info from /proc/net/softnet_stat
- -n, --netdev   show info from /proc/net/dev
- -g, --bonding  show info from /proc/net/bonding
- -i, --ip       show info from ip addr (BASH v4+ required)
-     --net      alias for: --lspci --ethtool --softirq --netdev --bonding --ip
- -s, --sysctl   show important kernel sysctls
- -p, --ps       inspect running processes via ps
+ -a, --all       show everything
+ -b, --bios      show info from dmidecode
+ -o, --os        show hostname, distro, SELinux, kernel info, uptime, etc
+ -k, --kdump     inspect kdump configuration
+ -c, --cpu       show info from /proc/cpuinfo
+ -f, --intrupt   show info from /proc/interrupts
+ -m, --mem       show info from /proc/meminfo
+ -d, --disks     show info from /proc/partitions, dm-multipath, lsblk, df
+ -t, --mpath     show info from dm-multipath
+ -l, --lspci     show info from lspci
+ -e, --ethtool   show info from ethtool
+ -r, --softirq   show info from /proc/net/softnet_stat
+ -n, --netdev    show info from /proc/net/dev
+ -g, --bonding   show bonding and teaming info
+ -i, --ip        show info from ip addr (BASH v4+ required)
+     --net       alias for: --lspci --ethtool --softirq --netdev --bonding --ip
+ -s, --sysctl    show important kernel sysctls
+ -p, --ps        inspect running processes via ps
+ -S, --ss        inspect running processes via ss
+ -F, --firewall  show firewall status
+ -I, --ifcfg     show ifcfg files summary
+ -N, --netstat   show info from /proc/net/netstat
 
 Display options:
-     --scrub-ip     remove IP addresses & hostnames from output
-     --scrub-mac    remove HW MAC addresses from output
-                    see XSOS_SCRUB_IP_HN & XSOS_SCRUB_MACADDR env vars
+     --scrub        remove from output: IP/MAC addrs, hostnames, serial numbers,
+                    proxy user & passwords
  -6, --ipv6         parse ip addr output for IPv6 addresses instead of IPv4
  -q, --wwid=ID      restrict dm-multipath output to a particular mpath device,
                     where ID is a wwid, friendly name, or LUN identifier
  -u, --unit=P       change byte display for /proc/meminfo & /proc/net/dev,
                     where P is "b" for byte, or else "k", "m", "g", or "t"
+     --threads      make ps take threads into account (via `ps auxm`)
  -v, --verbose=NUM  specify ps verbosity level (0-4, default: 1)
  -w, --width=NUM    change fold-width, in columns (positive number, e.g., 80)
                     "0" disables wrapping, "w" autodetects width (default)
@@ -163,6 +167,7 @@ Display options:
 Special options (BASH v4+ required):
  --B=FILE  read from FILE containing `dmidecode` dump
  --C=FILE  read from FILE containing /proc/cpuinfo dump
+ --F=FILE  read from FILE containing /proc/interrupts dump
  --M=FILE  read from FILE containing /proc/meminfo dump
  --D=FILE  read from FILE containing /proc/partitions dump
  --T=FILE  read from FILE containing `multipath -v4 -ll` dump
@@ -175,7 +180,7 @@ Special options (BASH v4+ required):
 
 Run with "--help" to see full help page
 
-Version info: xsos v0.5.6 last mod 2015/01/01
+Version info: xsos v0.7.40 last mod 2025-12-01
 See <github.com/ryran/xsos> to report bugs or suggestions
 ```
 

--- a/xsos
+++ b/xsos
@@ -250,8 +250,8 @@ Content options:"
  -p, --ps❚inspect running processes via ps
  -S, --ss❚inspect running processes via ss
  -F, --firewall❚show firewall status
- -I, --ifcfg❚|show ifcfg files summary
- -N, --netstat❚|show ifcfg files summary" | column -ts❚
+ -I, --ifcfg❚show ifcfg files summary
+ -N, --netstat❚show info from /proc/net/netstat" | column -ts❚
 }
 
 HELP_OPTS_DISPLAY() {
@@ -290,9 +290,7 @@ Special options (BASH v4+ required):"
  --N=FILE❚read from FILE containing /proc/net/dev dump
  --G=FILE❚read from FILE containing /proc/net/bonding/xxx dump
  --I=FILE❚read from FILE containing \`ip addr\` dump
- --P=FILE❚read from FILE containing \`ps aux\` dump
- --S=FILE❚read from FILE containing \`ss -peaonmi\` dump
- --F=FILE❚read from FILE containing \`systemctl_status_--all\` dump" | column -ts❚
+ --P=FILE❚read from FILE containing \`ps aux\` dump" | column -ts❚
 }
 
 HELP_SHORT() {
@@ -480,7 +478,6 @@ PARSE() {
       --G)  sfile[G]=$2; shift ;;
       --I)  sfile[I]=$2; shift ;;
       --P)  sfile[P]=$2; shift ;;
-      --S)  sfile[S]=$2; shift ;;
     esac
     shift
   done
@@ -3979,8 +3976,6 @@ trap "rm -rf $TMPDIR 2>/dev/null" EXIT
     [[ -r ${sfile[G]} ]] && BONDING   "${sfile[G]}"
     [[ -r ${sfile[I]} ]] && IPADDR    "${sfile[I]}"
     [[ -r ${sfile[P]} ]] && PSCHECK   "${sfile[P]}"
-    [[ -r ${sfile[S]} ]] && SSCHECK   "${sfile[S]}"
-    [[ -r ${sfile[F]} ]] && FIREWALL  "${sfile[F]}"
 
   # If SOSREPORT-ROOT provided, use that
   elif [[ -n $sosroot ]]; then

--- a/xsos
+++ b/xsos
@@ -1072,7 +1072,7 @@ OSINFO() {
     runlevel=$(runlevel)
     initdefault=$(basename $(readlink -q /etc/systemd/system/default.target) 2>/dev/null) &&
       initdefault=${initdefault%.target} ||
-        initdefault=$(gawk -F: '/^id.*initdefault/ {print $2}' </etc/inittab)
+        [[ -r /etc/inittab ]] && initdefault=$(gawk -F: '/^id.*initdefault/ {print $2}' </etc/inittab)
     
   # Otherwise, running on sosreport
   else

--- a/xsos
+++ b/xsos
@@ -290,7 +290,9 @@ Special options (BASH v4+ required):"
  --N=FILE❚read from FILE containing /proc/net/dev dump
  --G=FILE❚read from FILE containing /proc/net/bonding/xxx dump
  --I=FILE❚read from FILE containing \`ip addr\` dump
- --P=FILE❚read from FILE containing \`ps aux\` dump" | column -ts❚
+ --P=FILE❚read from FILE containing \`ps aux\` dump
+ --S=FILE❚read from FILE containing \`ss -peaonmi\` dump
+ --F=FILE❚read from FILE containing \`systemctl_status_--all\` dump" | column -ts❚
 }
 
 HELP_SHORT() {
@@ -478,12 +480,13 @@ PARSE() {
       --G)  sfile[G]=$2; shift ;;
       --I)  sfile[I]=$2; shift ;;
       --P)  sfile[P]=$2; shift ;;
+      --S)  sfile[S]=$2; shift ;;
     esac
     shift
   done
   shift #(to get rid of the '--')
   # Set sosroot
-  sosroot=$@
+  sosroot="$@"
 }
 
 # Call the parser
@@ -2171,7 +2174,7 @@ TEAMING() {
   # If an sosreport, look for sos_commands/teamd/ output...
   else
     files=("$1"/sos_commands/teamd/teamdctl_*_state_dump)
-    if [[ ! -r ${files[0]} ]]; then
+    if [[ ! -r "${files[0]}" ]]; then
       echo -e "${c[Warn2]}Warning:${c[Warn1]} '/sos_commands/teamd/teamdctl_*_state_dump' files unreadable; skipping teaming check${c[0]}" >&2
       echo -en $XSOS_HEADING_SEPARATOR >&2
       return
@@ -2193,7 +2196,7 @@ TEAMING() {
     echo "  Device❚Runner (mode) ❚ifcfg-File TEAM_CONFIG❚Partner MAC Addr❚Ports (*=active; [n]=AggID)"
     echo "  ========❚=================❚========================❚==================❚==============================="
     
-    f=0; for team_input in ${files[@]}; do
+    f=0; for team_input in "${files[@]}"; do
       
       team_name=$(gawk -F '"' '/team_device/,/^$/ {if ($2 == "ifname") {print $4}}' $team_input)
       echo -n "  $team_name❚"
@@ -2293,7 +2296,7 @@ BONDING() {
   # If localhost or sosreport, use that
   else
     files=("$1"/proc/net/bonding/*)
-    if [[ ! -r ${files[0]} ]]; then
+    if [[ ! -r "${files[0]}" ]]; then
       echo -e "${c[Warn2]}Warning:${c[Warn1]} '/proc/net/bonding/' files unreadable; skipping bonding check${c[0]}" >&2
       echo -en $XSOS_HEADING_SEPARATOR >&2
       return
@@ -2343,7 +2346,7 @@ BONDING() {
     echo "  Device❚Mode❚ifcfg-File BONDING_OPTS❚Partner MAC Addr❚Slaves (*=active; [n]=AggID)"
     echo "  ========❚=================❚========================❚==================❚==============================="
     
-    f=0; for bond_input in ${files[@]}; do
+    f=0; for bond_input in "${files[@]}"; do
       
       echo -n "  ${bond_input##*/}❚"
       
@@ -3379,7 +3382,7 @@ PSCHECK() {
   fi
   
   # Calculate top cpu-using & mem-using users
-  if [[ $XSOS_PS_LEVEL < 3 ]]; then  # If verbosity level 0-2, restrict number of users shown
+  if [[ $XSOS_PS_LEVEL -lt 3 ]]; then  # If verbosity level 0-2, restrict number of users shown
     # Process ps input to generate summary user-list of top-users
     top_users=$(
       gawk -vu=$(tr '[:lower:]' '[:upper:]' <<<"$XSOS_PS_UNIT") '
@@ -3879,7 +3882,7 @@ NETSTAT(){
   }
   _print_proc_net_array(){
     declare -A __array="$*"
-    for hdr in ${!__array[@]}; do
+    for hdr in "${!__array[@]}"; do
       val="${__array[$hdr]}"
       [ "${XSOS_NETSTAT_IGNORE_ZERO}" == "y" ]   && [ "$val" -eq "0" ] && continue
       [ "${XSOS_NETSTAT_FILTER_REGEX}" != "" ]    && [[ ! ${hdr,,} =~ ${XSOS_NETSTAT_FILTER_REGEX,,} ]]    && continue
@@ -3976,6 +3979,8 @@ trap "rm -rf $TMPDIR 2>/dev/null" EXIT
     [[ -r ${sfile[G]} ]] && BONDING   "${sfile[G]}"
     [[ -r ${sfile[I]} ]] && IPADDR    "${sfile[I]}"
     [[ -r ${sfile[P]} ]] && PSCHECK   "${sfile[P]}"
+    [[ -r ${sfile[S]} ]] && SSCHECK   "${sfile[S]}"
+    [[ -r ${sfile[F]} ]] && FIREWALL  "${sfile[F]}"
 
   # If SOSREPORT-ROOT provided, use that
   elif [[ -n $sosroot ]]; then

--- a/xsos-bash-completion.bash
+++ b/xsos-bash-completion.bash
@@ -36,11 +36,11 @@ _xsos()  {
             -6 -q -u -v -w
             -x -y -z"
             
-  longopts="--help --version
-            --all --bios --os --kdump --cpu --intrupt --mem --disks --mpath --lspci --ethtool --softirq --netdev --bonding --ip --net --sysctl --ps -ss --firewall --ifcfg --netstat
-            --B --C --F --M --D --T --L --R --N --G --I --P
-            --scrub --ipv6 --wwid --unit --threads --verbose --width
-            --nocolor --less --more"
+    longopts="--help --version
+                        --all --bios --os --kdump --cpu --intrupt --mem --disks --mpath --lspci --ethtool --softirq --netdev --bonding --ip --net --sysctl --ps --ss --firewall --ifcfg --netstat
+                        --B --C --F --M --D --T --L --R --N --G --I --P
+                        --scrub --ipv6 --rhsupport --wwid --unit --threads --verbose --width
+                        --nocolor --less --more"
   
   # Check previous arg to see if we need to do anything special
   case "$prev" in

--- a/xsos-bash-completion.bash
+++ b/xsos-bash-completion.bash
@@ -36,11 +36,11 @@ _xsos()  {
             -6 -q -u -v -w
             -x -y -z"
             
-    longopts="--help --version
-                        --all --bios --os --kdump --cpu --intrupt --mem --disks --mpath --lspci --ethtool --softirq --netdev --bonding --ip --net --sysctl --ps --ss --firewall --ifcfg --netstat
-                        --B --C --F --M --D --T --L --R --N --G --I --P
-                        --scrub --ipv6 --rhsupport --wwid --unit --threads --verbose --width
-                        --nocolor --less --more"
+  longopts="--help --version
+            --all --bios --os --kdump --cpu --intrupt --mem --disks --mpath --lspci --ethtool --softirq --netdev --bonding --ip --net --sysctl --ps -ss --firewall --ifcfg --netstat
+            --B --C --F --M --D --T --L --R --N --G --I --P
+            --scrub --ipv6 --wwid --unit --threads --verbose --width
+            --nocolor --less --more"
   
   # Check previous arg to see if we need to do anything special
   case "$prev" in


### PR DESCRIPTION
For commit f3f166a
- Update README minimal help snippet to match current xsos -h output (v0.7.40)
- Document local lint commands in CONTRIB.md
- Add GitHub Actions workflow to run bash -n and shellcheck (errors only)